### PR TITLE
workflows: Add `verible` action for linting Verilog files

### DIFF
--- a/.github/workflows/lint-verilog.yaml
+++ b/.github/workflows/lint-verilog.yaml
@@ -1,0 +1,13 @@
+name: Verible linter
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: chipsalliance/verible-linter-action@main
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The action verifies the Verilog changes in each PR for coding style, and common pitfalls.